### PR TITLE
#3 Start with gestures

### DIFF
--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -70,6 +70,7 @@ public:
 	void setTouchWidth(uint16_t width);
 	void setTouchHeight(uint16_t height);
 	void setTapThreshold(uint8_t millis);
+	void setEnableGestures(bool enabled);
 	// Pending implementation. How much x->touch y↓touch is placed (In case is smaller than display)
 	void setXoffset(uint16_t x_offset);
 	void setYoffset(uint16_t y_offset);
@@ -120,7 +121,7 @@ private:
 	uint16_t minX = 0;
 	uint16_t minY = 0;
 	
-	bool _dragMode = false;
+	bool enableGestures = false;
 	const uint8_t maxDeviation = 5;
 	
 	bool pressUnlock = true;

--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -69,7 +69,7 @@ public:
 	void setRotation(uint8_t rotation);
 	void setTouchWidth(uint16_t width);
 	void setTouchHeight(uint16_t height);
-	void setTapThreshold(uint8_t millis);
+	void setTapThreshold(uint64_t micros);
 	void setEnableGestures(bool enabled);
 	// Pending implementation. How much x->touch y↓touch is placed (In case is smaller than display)
 	void setXoffset(uint16_t x_offset);
@@ -99,9 +99,6 @@ private:
 
 	static L58Touch * _instance;
 	uint8_t _intPin;
-	// Milliseconds between press and release for Event detection
-	uint8_t _tap_threshold = 160;
-	uint8_t _swing_threshold = 200;
 	
 	// Make touch rotation aware:
 	uint8_t _rotation = 0;
@@ -112,10 +109,14 @@ private:
 	uint16_t _touchX[2], _touchY[2], _touchEvent[2];
 	TPoint _points[10];
 	uint8_t _pointIdx = 0;
-	unsigned long _touchStartTime = 0;
-	unsigned long _touchEndTime = 0;
-	unsigned long _touchLastTapTime = 0;
-	unsigned long _touchLastSwing = 0;
+	// Touch time measurements in micros
+	uint64_t _touchStartTime = 0;
+	uint64_t _touchEndTime = 0;
+	uint64_t _touchLastTapTime = 0;
+	uint64_t _touchLastSwing = 0;
+
+	// Milliseconds between press and release for Event detection
+	uint64_t _tap_threshold = 150000;
 	
 	// Used to detect first X on event 3 (Press)
 	uint16_t minX = 0;

--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -31,10 +31,11 @@
 enum class TEvent
 {
 	None,
-	TouchStart,
-	TouchMove,
-	TouchEnd,
-	Tap
+	SwingLeft,  // 1
+	SwingRight, // 2
+	SwingUp,    // 3
+	Tap,        // 4
+	DoubleTap   // 5
 };
 
 struct TPoint
@@ -83,7 +84,6 @@ public:
     }
 	void(*_touchHandler)(TPoint point, TEvent e) = nullptr;
 	TouchData_t data[5];
-	bool tapDetectionEnabled = true;
 	
 private:
 	TPoint scanPoint();
@@ -98,8 +98,8 @@ private:
 	static L58Touch * _instance;
 	uint8_t _intPin;
 	// Milliseconds between press and release for Tap detection
-	uint8_t _tap_threshold = 150;
-
+	uint8_t _tap_threshold = 160;
+	
 	// Make touch rotation aware:
 	uint8_t _rotation = 0;
 	uint16_t _touch_width = 0;
@@ -111,11 +111,16 @@ private:
 	uint8_t _pointIdx = 0;
 	unsigned long _touchStartTime = 0;
 	unsigned long _touchEndTime = 0;
-    uint8_t lastEvent = 3; // No event
+	unsigned long _touchLastTapTime = 0;
 	uint16_t lastX = 0;
 	uint16_t lastY = 0;
 	bool _dragMode = false;
 	const uint8_t maxDeviation = 5;
+	const uint8_t tapCoordDiff = 1;
+	bool pressUnlock = true;
+
+	TEvent lastEvent = TEvent::None;
+	const char *enumEvents[6] = {"None", "SwingLeft", "SwingRight", "SwingUp", "Tap", "DoubleTap"};
 };
 
 #endif

--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -114,7 +114,7 @@ private:
 	unsigned long _touchStartTime = 0;
 	unsigned long _touchEndTime = 0;
 	unsigned long _touchLastTapTime = 0;
-
+	unsigned long _touchLastSwing = 0;
 	
 	// Used to detect first X on event 3 (Press)
 	uint16_t minX = 0;

--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -64,6 +64,7 @@ public:
 	uint8_t touched();
 	void loop();
 	void processTouch();
+	bool processGesture(TPoint point, unsigned long timeDiff);
 	// Helper functions to make the touch display aware
 	void setRotation(uint8_t rotation);
 	void setTouchWidth(uint16_t width);
@@ -97,8 +98,9 @@ private:
 
 	static L58Touch * _instance;
 	uint8_t _intPin;
-	// Milliseconds between press and release for Tap detection
+	// Milliseconds between press and release for Event detection
 	uint8_t _tap_threshold = 160;
+	uint8_t _swing_threshold = 200;
 	
 	// Make touch rotation aware:
 	uint8_t _rotation = 0;
@@ -112,11 +114,15 @@ private:
 	unsigned long _touchStartTime = 0;
 	unsigned long _touchEndTime = 0;
 	unsigned long _touchLastTapTime = 0;
-	uint16_t lastX = 0;
-	uint16_t lastY = 0;
+
+	
+	// Used to detect first X on event 3 (Press)
+	uint16_t minX = 0;
+	uint16_t minY = 0;
+	
 	bool _dragMode = false;
 	const uint8_t maxDeviation = 5;
-	const uint8_t tapCoordDiff = 1;
+	
 	bool pressUnlock = true;
 
 	TEvent lastEvent = TEvent::None;


### PR DESCRIPTION
Adding gestures. This PR should take care of handling Taps differently in order to allow other gestures.

A Tap should be done in an X, Y release place that is close to the press coordinates. 
That way taking in account the timing (longer) from a swipe gesture we could make some maths and try to guess what direction it was. The problem with this implementation is that if does not work intuitively and it's not precise it might make the Tap event that was previously working, work worse or be confused with a swipe. 
With that in mind it will need some testing before being merged. For that we can just copy / paste the modified include and L58Touch.cpp in the libs folder so we can test it with existing DIY-epub-reader