### PR TITLE
Switch to functional callback so that closures can be used

### DIFF
--- a/FT6X36.cpp
+++ b/FT6X36.cpp
@@ -77,9 +77,9 @@ bool FT6X36::begin(uint8_t threshold, uint16_t width, uint16_t height)
 	return true;
 }
 
-void FT6X36::registerTouchHandler(void (*fn)(TPoint point, TEvent e))
+void FT6X36::registerTouchHandler(FT6X36TouchHandlerCallback touch_handler)
 {
-	_touchHandler = fn;
+	_touchHandler = touch_handler;
 	if (CONFIG_FT6X36_DEBUG) printf("Touch handler function registered\n");
 }
 

--- a/L58Touch.cpp
+++ b/L58Touch.cpp
@@ -69,9 +69,9 @@ bool L58Touch::begin(uint16_t width, uint16_t height)
 	return true;
 }
 
-void L58Touch::registerTouchHandler(void (*fn)(TPoint point, TEvent e))
+void L58Touch::registerTouchHandler(L58TouchHandlerCallback touch_handler)
 {
-	_touchHandler = fn;
+    _touchHandler = touch_handler;
 	if (CONFIG_FT6X36_DEBUG) printf("Touch handler function registered\n");
 }
 

--- a/include/FT6X36.h
+++ b/include/FT6X36.h
@@ -5,6 +5,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include <stdio.h>
+#include <functional>
 #include "esp_log.h"
 #include "driver/i2c.h"
 #include "sdkconfig.h"
@@ -118,7 +119,7 @@ struct TPoint
 	}
 };
 
-
+typedef std::function<void(TPoint point, TEvent e)> FT6X36TouchHandlerCallback;
 
 class FT6X36
 {
@@ -128,7 +129,7 @@ public:
 	FT6X36(int8_t intPin);
 	~FT6X36();
 	bool begin(uint8_t threshold = FT6X36_DEFAULT_THRESHOLD, uint16_t width = 0, uint16_t height = 0);
-	void registerTouchHandler(void(*fn)(TPoint point, TEvent e));
+	void registerTouchHandler(FT6X36TouchHandlerCallback touch_handler);
 	uint8_t touched();
 	void loop();
 	void processTouch();
@@ -148,7 +149,7 @@ public:
       a = b;
       b = t;
     }
-	void(*_touchHandler)(TPoint point, TEvent e) = nullptr;
+	FT6X36TouchHandlerCallback _touchHandler = nullptr;
 	
 private:
 	bool readData(void);

--- a/include/L58Touch.h
+++ b/include/L58Touch.h
@@ -10,6 +10,7 @@
 #include "freertos/task.h"
 #include "freertos/semphr.h"
 #include <stdio.h>
+#include <functional>
 #include "esp_log.h"
 #include "driver/i2c.h"
 #include "sdkconfig.h"
@@ -44,6 +45,8 @@ struct TPoint
 	uint8_t event;
 };
 
+typedef std::function<void(TPoint point, TEvent e)> L58TouchHandlerCallback;
+
 class L58Touch
 {
 	static void IRAM_ATTR isr(void* arg);
@@ -59,7 +62,7 @@ public:
 	L58Touch(int8_t intPin);
 	~L58Touch();
 	bool begin(uint16_t width = 0, uint16_t height = 0);
-	void registerTouchHandler(void(*fn)(TPoint point, TEvent e));
+	void registerTouchHandler(L58TouchHandlerCallback touch_handler);
 	uint8_t touched();
 	void loop();
 	void processTouch();
@@ -81,7 +84,7 @@ public:
       a = b;
       b = t;
     }
-	void(*_touchHandler)(TPoint point, TEvent e) = nullptr;
+	L58TouchHandlerCallback _touchHandler = nullptr;
 	TouchData_t data[5];
 	bool tapDetectionEnabled = true;
 	


### PR DESCRIPTION
This should allow the use of both C style function pointers and C++ lambdas.

Probably needs a bit of testing - I'll try it out on my LilyGo