### PR TITLE
Support polling of touch controller

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -2,11 +2,11 @@ menu "Touch FT6X36 Configuration"
     comment "The touch chip needs an I2C port and one input GPIO"
     config TOUCH_SDA
         int "I2C data SDA"
-        range 0 35
+        range 0 38
         default 21
     config TOUCH_SDL
         int "I2C clock SDL"
-        range 0 37
+        range 0 39
         default 22
     config TOUCH_INT
         int "Touch interrupt: On LOW reads the data via I2C (Input pullup)"

--- a/include/FT6X36.h
+++ b/include/FT6X36.h
@@ -134,6 +134,7 @@ public:
 	void loop();
 	void processTouch();
 	void debugInfo();
+	void poll(TPoint * point, TEvent * event);
 	// Helper functions to make the touch display aware
 	void setRotation(uint8_t rotation);
 	void setTouchWidth(uint16_t width);
@@ -159,7 +160,7 @@ private:
 	uint8_t read8(uint8_t regName);
 	static FT6X36 * _instance;
 	
-	uint8_t _intPin;
+	int8_t _intPin;
 	
 	// Make touch rotation aware:
 	uint8_t _rotation = 0;


### PR DESCRIPTION
- Allow for no interrupt pin
- Add poll() for simple polled touch interface
- Utilize the interrupt pin specified in construction
- Expand allowable range of I2C interface pins

This code is currently compiled and running on an Elecrow ESP32 Terminal with the interrupt (`CONFIG_TOUCH_INT = -1`)